### PR TITLE
Improve id generator

### DIFF
--- a/lib/Task.js
+++ b/lib/Task.js
@@ -15,7 +15,7 @@ function _generateId() {
     let id = "";
     for (let n = 0; n < 16; n++)
         id += String.fromCharCode(_getRandomValue());
-    return Buffer.from(id).toString('base64').replace(/\//g, "_").replace(/\+/g, "-")
+    return Buffer.from(id).toString('base64').replace(/\//g, "_").replace(/\+/g, "-").slice(-24)
 
 }
 


### PR DESCRIPTION
The id generated before was not 100% correct. Any.do generates 24 length base64 strings. With the previous method sometimes the length of the id was larger. This caused some issues with syncing, specifically with syncing shared categories.